### PR TITLE
Merge FAQ entries

### DIFF
--- a/src/data/faq.json
+++ b/src/data/faq.json
@@ -1125,7 +1125,7 @@
                                     "The risk status is automatically updated up to 6 times a day if a WLAN connection is available. In the case of a mobile Internet connection, the risk status is only queried once a day. You can find more information here: <a href='#risk_update_24' target='_blank'>How often is the risk status updated?</a>",
                                     "<b>How do different risk assessments arise among users who have been in the same place?</b>",
                                     "Deviating infection risk scores can have multiple causes, but do not affect the effectiveness of the Corona-Warn-App.",
-                                    "The assessment of a possible risk of infection depends on the detected contact duration and the determined distance between the smartphones. The determination of the distance is also influenced by the orientation of the two smartphone antennas to each other. Therefore, this aspect of the risk assessment is highly dependent on the exact spatial location of the smartphones involved. You can find more information here: <a href='#dissimilar_indication_of_risk_status' target='_blank'>Dissimilar indication of risk status</a>",
+                                    "The assessment of a possible risk of infection depends on the detected contact duration and the determined distance between the smartphones. The determination of the distance is also influenced by the orientation of the two smartphone antennas to each other. Therefore, this aspect of the risk assessment is highly dependent on the exact spatial location of the smartphones involved. You can find more information here: <a href='#risk_encounter_different_devices' target='_blank'>Dissimilar indication of risk status</a>",
                                     "<br>",
                                     "<h3>Testing</h3>",
                                     "<hr>",
@@ -2611,18 +2611,6 @@
                                 "active": false,
                                 "textblock": [
                                     "With version 2.19 of the Corona-Warn-App, the matching of positive keys has been optimized under Android. Previously, the risk calculation always compared all keys downloaded from the server with the keys collected by the operating system. With the update, multiple matching of data is avoided, and only new and previously unaccounted keys are checked. For example, whereas previously 4 million keys were checked, with this optimization it is now typically only between about 4000 and 40000 key matches (with occurrence of infection as of March 2022). The number of keys matched displayed in the operating system (COVID-19 exposure notifications) will also be lower. However, this will not affect the risk encounters displayed by the Corona-Warn-App in the red or green tile."
-                                ]
-                            },
-                            {
-                                "title": "Dissimilar indication of risk status",
-                                "anchor": "dissimilar_indication_of_risk_status",
-                                "active": false,
-                                "textblock": [
-                                    "Why do differences in infection risk status appear in different CWA apps, even for close-by smartphones?",
-                                    "Varying infection risk ratings are caused by several reasons. However, they do not affect the effectiveness of the Corona-Warn-App (CWA).",
-                                    "The assessment of a possible infection risk depends on the recorded contact duration and the determined distance to the smartphone of a CWA user who reported the positive test result.  The distance determination is thereby also affected by the orientation of the two smartphone antennas with respect to each other. Therefore, this aspect of the risk assessment depends largely on physical location of the involved smartphones and on spatial conditions.",
-                                    "Moreover, many processes on the smartphones are background processes; they will start at different times depending on the scheduling of the operating system.  Examples of those processes are the risk calculation process, downloading of positive keys that takes place several times a day when WiFi access is available, and as well the scanning for other smartphones with an active CWA running.",
-                                    "Furthermore, the CWA supports different Exposure Notification Framework (ENF) versions, depending on the version number of the app and the used operating system. This framework is implemented and provided by Google and Apple. Since not every smartphone supports the latest ENF release, also different ENF versions may lead to different risk calculations."
                                 ]
                             },
                             {

--- a/src/data/faq_de.json
+++ b/src/data/faq_de.json
@@ -1124,7 +1124,7 @@
                                     "<b>Wie häufig wird der Risikostatus aktualisiert?</b>",
                                     "Der Risikostatus wird bis zu 6 mal täglich automatisch aktualisiert, wenn eine WLAN-Verbindung vorhanden ist. Bei einer mobilen Internetverbindung wird der Risikostatus lediglich einmal täglich abgefragt. Weitere Informationen erhalten Sie hier: <a href='#risk_update_24' target='_blank'>Wie oft wird der Risiko-Status aktualisiert?</a>",
                                     "<b>Wie entstehen unterschiedliche Risikobewertungen bei Nutzern, die sich am gleichen Ort aufgehalten haben?</b>",
-                                    "Abweichende Infektionsrisikobewertungen können mehrere Ursachen haben, beeinträchtigen aber nicht die Wirksamkeit der Corona-Warn-App.<br>Die Einschätzung eines möglichen Infektionsrisikos hängt von der erkannten Kontaktdauer und dem ermittelten Abstand zwischen den Smartphones ab. Die Ermittlung des Abstandes wird dabei auch von der Ausrichtung der beiden Smartphone-Antennen zueinander beeinflusst. Daher ist dieser Aspekt der Risikobewertung sehr stark von der exakten räumlichen Lage der beteiligten Smartphones abhängig. Weitere Informationen erhalten Sie hier: <a href='#dissimilar_indication_of_risk_status' target='_blank'>Unterschiedliche Anzeige von Risiken</a>",
+                                    "Abweichende Infektionsrisikobewertungen können mehrere Ursachen haben, beeinträchtigen aber nicht die Wirksamkeit der Corona-Warn-App.<br>Die Einschätzung eines möglichen Infektionsrisikos hängt von der erkannten Kontaktdauer und dem ermittelten Abstand zwischen den Smartphones ab. Die Ermittlung des Abstandes wird dabei auch von der Ausrichtung der beiden Smartphone-Antennen zueinander beeinflusst. Daher ist dieser Aspekt der Risikobewertung sehr stark von der exakten räumlichen Lage der beteiligten Smartphones abhängig. Weitere Informationen erhalten Sie hier: <a href='#risk_encounter_different_devices' target='_blank'>Unterschiedliche Anzeige von Risiken</a>",
                                     "<br>",
                                     "<h3>Testen</h3>",
                                     "<hr>",
@@ -2621,18 +2621,6 @@
                                 "active": false,
                                 "textblock": [
                                     "Mit der Version 2.19 der Corona-Warn-App wurde unter Android der Abgleich der positiven Schlüssel optimiert. Zuvor wurden in der Risikoberechnung immer alle vom Server heruntergeladenen Schlüssel mit den vom Betriebssystem gesammelten Schüsseln verglichen. Mit dem Update wird das mehrfache Abgleichen von Daten vermieden, und nur neue und zuvor nicht berücksichtigte Schlüssel werden kontrolliert. Während zuvor beispielsweise 4 Millionen Schlüssel in einem Abgleich kontrolliert wurden, sind es mit dieser Optimierung nur noch typischerweise zwischen etwa 4000 und 40000 Schlüsselabgleiche (mit dem Infektionsgeschehen Stand März 2022). Auch die Anzahl der im Betriebssystem (Begegnungsaufzeichnungen) angezeigten Übereinstimmungen von Schlüsseln wird geringer ausfallen. Das hat jedoch keinen Einfluss auf die von der Corona-Warn-App angezeigten Risikobegegnungen in der roten oder grünen Kachel."
-                                ]
-                            },
-                            {
-                                "title": "Unterschiedliche Anzeige von Risiken",
-                                "anchor": "dissimilar_indication_of_risk_status",
-                                "active": false,
-                                "textblock": [
-                                    "Wie kommt es zu Unterschieden in der Infektionsrisikobewertung durch verschiedene CWA Apps, auch wenn die jeweiligen Smartphones sich nicht weit voneinander entfernt befanden?",
-                                    "Abweichende Infektionsrisikobewertungen können mehrere Ursachen haben, beeinträchtigen aber nicht die Wirksamkeit der Corona-Warn-App (CWA).",
-                                    "Die Einschätzung eines möglichen Infektionsrisikos hängt von der erkannten Kontaktdauer und dem ermittelten Abstand zum dem Smartphone eines CWA Nutzers ab, der sich dazu entschlossen hat, seinen positiven Testbescheid zu teilen. Die Ermittlung des Abstandes wird dabei auch von der Ausrichtung der beiden Smartphone-Antennen zueinander beeinflusst. Daher ist dieser Aspekt der Risikobewertung sehr stark von der exakten räumlichen Lage der beteiligten Smartphones abhängig.",
-                                    "Zudem laufen viele Prozesse auf den Smartphones im Hintergrund ab und können daher zu unterschiedlichen Zeitpunkten starten. Beispiele für solche Prozesse sind die Risikoberechnung, das bei bestehendem WiFi-Zugang mehrfach am Tag stattfindende Laden von Positivschlüsseln. Aber auch die Suche nach anderen Smartphones mit aktiver CWA ist ein solcher Hintergrundprozess. ",
-                                    "Des Weiteren unterstützt die CWA (abhängig von der Versionsnummer der App und dem genutzten Betriebssystem) unterschiedliche Versionen des Exposure Notification Framework (ENF). Dieses wird von Google und Apple entwickelt und zur Verfügung gestellt. Da nicht jedes Smartphone die neueste Version des ENF unterstützt, können unterschiedliche ENF Versionen zu abweichenden Risiko-Berechnungen führen."
                                 ]
                             },
                             {

--- a/src/data/faq_redirects.json
+++ b/src/data/faq_redirects.json
@@ -8,5 +8,6 @@
     "vac_booster": "vac_cert_booster",
     "vac_cert_invalid_211111": "vac_cert_invalid_21_1",
     "vac_cert_verification": "eu_dcc_check",
-    "in_short": "in_a_nutshell"
+    "in_short": "in_a_nutshell",
+    "dissimilar_indication_of_risk_status": "risk_encounter_different_devices"
 }


### PR DESCRIPTION
This commit removes the FAQ entry "dissimilar_indication_of_risk_status" & adds a redirect to the FAQ entry "risk_encounter_different_devices" instead.