### PR TITLE
Remove TAN hotline info from footer

### DIFF
--- a/cypress/e2e/hotline.cy.js
+++ b/cypress/e2e/hotline.cy.js
@@ -7,9 +7,5 @@ describe('Test Hotline phone number', () => {
     cy.get('body').find('[data-e2e="hotline-app"]').contains('Hotline App')
     cy.get('body').find('[data-e2e="hotline-app"]').contains('0800 7540001')
     cy.get('body').find('[data-e2e="hotline-app"]').contains('+49 30 498 75401')
-
-    cy.get('body').find('[data-e2e="hotline-tan"]').contains('Hotline TAN')
-    cy.get('body').find('[data-e2e="hotline-tan"]').contains('0800 7540002')
-    cy.get('body').find('[data-e2e="hotline-tan"]').contains('+49 30 498 75402')
   })
 })

--- a/src/data/global.json
+++ b/src/data/global.json
@@ -370,24 +370,6 @@
                         }
                     ],
                     "testid": "hotline-app"
-                },
-                {
-                    "title": "Hotline TAN",
-                    "links": [
-                        {
-                            "title": "0800 7540002",
-                            "url": "tel:08007540002"
-                        },
-                        {
-                            "title": "+49 30 498 75402",
-                            "url": "tel:+493049875402"
-                        },
-                        {
-                            "title": "until Jan 31, 2023",
-                            "url": "/en/blog/2023-01-18-cwa-3-0/"
-                        }
-                    ],
-                    "testid": "hotline-tan"
                 }
             ],
             "copyright": {
@@ -572,24 +554,6 @@
                         }
                     ],
                     "testid": "hotline-app"
-                },
-                {
-                    "title": "Hotline TAN",
-                    "links": [
-                        {
-                            "title": "0800 7540002",
-                            "url": "tel:08007540002"
-                        },
-                        {
-                            "title": "+49 30 498 75402",
-                            "url": "tel:+493049875402"
-                        },
-                        {
-                            "title": "bis 31. Jan 2023",
-                            "url": "/de/blog/2023-01-18-cwa-3-0/"
-                        }
-                    ],
-                    "testid": "hotline-tan"
                 }
             ],
             "copyright": {


### PR DESCRIPTION
This commit removes the number of the TAN hotline from the footer and adapts the corresponding test.

TEST PR